### PR TITLE
fix: qstatus menubar v2 phase 1 — 6 correctness bug fixes

### DIFF
--- a/q-status-menubar/Package.resolved
+++ b/q-status-menubar/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "9e6ade5fafaf2e52e65b2579f87ce3647ea45d70f1e4630f9ded328c8835171d",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -7,6 +8,24 @@
       "state" : {
         "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
         "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-testing.git",
+      "state" : {
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
       }
     },
     {
@@ -19,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/q-status-menubar/Package.swift
+++ b/q-status-menubar/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -12,6 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.26.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.2"),
+        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
     ],
     targets: [
         .executableTarget(
@@ -19,7 +20,8 @@ let package = Package(
             dependencies: ["Core"],
             path: "Sources/App",
             swiftSettings: [
-                .define("SWIFTUI_APP")
+                .define("SWIFTUI_APP"),
+                .swiftLanguageMode(.v5)
             ]
         ),
         .target(
@@ -28,12 +30,22 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift"),
                 .product(name: "Yams", package: "Yams")
             ],
-            path: "Sources/Core"
+            path: "Sources/Core",
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]
         ),
         .testTarget(
             name: "CoreTests",
-            dependencies: ["Core"],
-            path: "Tests/CoreTests"
+            dependencies: [
+                "Core",
+                .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "Tests/CoreTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]
         )
     ]
 )

--- a/q-status-menubar/Sources/Core/QDBReader.swift
+++ b/q-status-menubar/Sources/Core/QDBReader.swift
@@ -86,14 +86,44 @@ public actor QDBReader: DataSource {
         guard let dbPool else { throw NSError(domain: "QDBReader", code: 1, userInfo: [NSLocalizedDescriptionKey: "DB not open"]) }
 
         let s = self.schema
+        let supportsJSON1 = await json1Available()
         return try await dbPool.read { db in
             let now = Date()
             guard let ct = s.conversationsTable, let keyCol = s.keyColumn, let valueCol = s.valueColumn else {
                 return UsageSnapshot(timestamp: now, tokensUsed: 0, messageCount: 0, conversationId: nil, sessionLimitOverride: nil)
             }
 
-            // Latest conversation by rowid (most recently inserted/updated)
-            let row = try Row.fetchOne(db, sql: "SELECT rowid, \(rawIdent(keyCol)) AS k, \(rawIdent(valueCol)) AS v FROM \(rawIdent(ct)) ORDER BY rowid DESC LIMIT 1")
+            let row: Row?
+            if supportsJSON1 {
+                // Find conversation with most recent activity timestamp
+                let sql = """
+                WITH latest_activity AS (
+                  SELECT c.rowid, c.\(rawIdent(keyCol)) AS k, c.\(rawIdent(valueCol)) AS v,
+                    MAX(
+                      COALESCE(
+                        json_extract(h.value,'$.assistant.timestamp'),
+                        json_extract(h.value,'$.assistant.created_at'),
+                        json_extract(h.value,'$.user.timestamp'),
+                        json_extract(h.value,'$.user.created_at')
+                      )
+                    ) AS last_ts
+                  FROM \(rawIdent(ct)) c
+                  LEFT JOIN json_each(
+                    CASE
+                      WHEN json_type(json_extract(c.\(rawIdent(valueCol)),'$.history')) = 'array'
+                      THEN json_extract(c.\(rawIdent(valueCol)),'$.history')
+                      ELSE '[]'
+                    END
+                  ) h ON 1
+                  GROUP BY c.rowid
+                )
+                SELECT * FROM latest_activity ORDER BY last_ts DESC, rowid DESC LIMIT 1
+                """
+                row = try Row.fetchOne(db, sql: sql)
+            } else {
+                // Fallback: rowid order when JSON1 is unavailable
+                row = try Row.fetchOne(db, sql: "SELECT rowid, \(rawIdent(keyCol)) AS k, \(rawIdent(valueCol)) AS v FROM \(rawIdent(ct)) ORDER BY rowid DESC LIMIT 1")
+            }
             let convId: String? = row?["k"]
             let convJSON: String? = row?["v"]
 
@@ -318,10 +348,44 @@ public actor QDBReader: DataSource {
     public func sessionCount(activeOnly: Bool = false) async throws -> Int {
         try await openIfNeeded()
         guard let dbPool else { return 0 }
-        // Always use conversations table (history table is never populated)
+        if !activeOnly {
+            return try await dbPool.read { db in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM conversations") ?? 0
+            }
+        }
+        // activeOnly: count conversations with activity in last 7 days
+        let supportsJSON1 = await json1Available()
+        if supportsJSON1 {
+            let cutoff = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-7*24*3600))
+            return try await dbPool.read { db in
+                let sql = """
+                SELECT COUNT(*) FROM (
+                  SELECT c.key,
+                    MAX(
+                      COALESCE(
+                        json_extract(h.value,'$.assistant.timestamp'),
+                        json_extract(h.value,'$.assistant.created_at'),
+                        json_extract(h.value,'$.user.timestamp'),
+                        json_extract(h.value,'$.user.created_at')
+                      )
+                    ) AS last_ts
+                  FROM conversations c
+                  LEFT JOIN json_each(
+                    CASE
+                      WHEN json_type(json_extract(c.value,'$.history')) = 'array'
+                      THEN json_extract(c.value,'$.history')
+                      ELSE '[]'
+                    END
+                  ) h ON 1
+                  GROUP BY c.key
+                  HAVING last_ts >= ?
+                )
+                """
+                return try Int.fetchOne(db, sql: sql, arguments: [cutoff]) ?? 0
+            }
+        }
+        // Fallback: return total count (can't filter without JSON1)
         return try await dbPool.read { db in
-            // For now, activeOnly filter would need JSON parsing of timestamps
-            // Since history table is unused, we can't filter by activity time reliably
             try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM conversations") ?? 0
         }
     }
@@ -370,7 +434,7 @@ public actor QDBReader: DataSource {
                 let totalSessions: Int = agg?["total_sessions"] ?? 0
                 let totalChars: Int = agg?["total_chars"] ?? 0
                 let nearCount: Int = agg?["near_count"] ?? 0
-                let totalTokens = Int((((Double(totalChars)/4.0) + 5.0) / 10.0).rounded(.down) * 10.0)
+                let totalTokens = TokenEstimator.estimate(charCount: totalChars)
 
                 // Top heavy sessions by estimated tokens
                 let topSQL = """
@@ -397,7 +461,7 @@ public actor QDBReader: DataSource {
                     let key: String = r["key"] ?? ""
                     let chars: Int = r["chars"] ?? 0
                     let ctx: Int = r["ctx"] ?? self.defaultContextWindow
-                    let tokens = Int((((Double(chars)/4.0) + 5.0) / 10.0).rounded(.down) * 10.0)
+                    let tokens = TokenEstimator.estimate(charCount: chars)
                     // Cap at 99.9% unless truly at or above limit
                     // Note: This percentage calculation remains here (not in PercentageCalculator)
                     // because QDBReader is a foundation layer that PercentageCalculator depends on.
@@ -413,7 +477,7 @@ public actor QDBReader: DataSource {
             return try await dbPool.read { db in
                 let totalSessions = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM conversations") ?? 0
                 let totalChars = try Int.fetchOne(db, sql: "SELECT SUM(length(value)) FROM conversations") ?? 0
-                let totalTokens = Int((((Double(totalChars)/4.0) + 5.0) / 10.0).rounded(.down) * 10.0)
+                let totalTokens = TokenEstimator.estimate(charCount: totalChars)
                 return GlobalMetrics(totalSessions: totalSessions, totalTokens: totalTokens, sessionsNearLimit: 0, topHeavySessions: [])
             }
         }
@@ -466,37 +530,40 @@ public actor QDBReader: DataSource {
         }
     }
 
-    // Monthly messages across all sessions.
-    // History table is never populated, so we estimate from conversations table
+    // Monthly messages across all sessions, filtered to current month only.
     public func fetchMonthlyMessageCount(now: Date = Date()) async throws -> Int {
         try await openIfNeeded()
         guard let dbPool else { return 0 }
-        
-        // Since history table is unused, estimate monthly messages from conversations
-        // This counts total messages in all conversations (not ideal but better than 0)
+
         let supportsJSON1 = await json1Available()
         if supportsJSON1 {
+            let cal = Calendar.current
+            let startOfMonth = cal.date(from: cal.dateComponents([.year,.month], from: now)) ?? cal.startOfDay(for: now)
+            let monthStr = ISO8601DateFormatter().string(from: startOfMonth)
             return try await dbPool.read { db in
-                // Sum up message counts from all conversations, handling both array and object types
+                // Count individual history entries whose timestamp falls in the current month
                 let sql = """
-                SELECT SUM(
-                  CASE 
-                    WHEN json_type(json_extract(value,'$.history')) = 'array' 
-                    THEN COALESCE(json_array_length(json_extract(value,'$.history')), 0)
-                    WHEN json_type(json_extract(value,'$.history')) = 'object'
-                    THEN COALESCE(json_array_length(json_extract(value,'$.history'), '$'), 0)
-                    ELSE 0
-                  END
-                ) 
-                FROM conversations
+                SELECT COUNT(*) FROM conversations c,
+                  json_each(
+                    CASE
+                      WHEN json_type(json_extract(c.value,'$.history')) = 'array'
+                      THEN json_extract(c.value,'$.history')
+                      ELSE '[]'
+                    END
+                  ) h
+                WHERE COALESCE(
+                  json_extract(h.value,'$.assistant.timestamp'),
+                  json_extract(h.value,'$.assistant.created_at'),
+                  json_extract(h.value,'$.user.timestamp'),
+                  json_extract(h.value,'$.user.created_at')
+                ) >= ?
                 """
-                return try Int.fetchOne(db, sql: sql) ?? 0
+                return try Int.fetchOne(db, sql: sql, arguments: [monthStr]) ?? 0
             }
         }
-        // Fallback: estimate based on conversation count
+        // Fallback: estimate based on conversation count (no timestamp filtering possible)
         return try await dbPool.read { db in
             let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM conversations") ?? 0
-            // Rough estimate: assume 20 messages per conversation on average
             return count * 20
         }
     }
@@ -574,84 +641,73 @@ public actor QDBReader: DataSource {
         guard await json1Available() else { return [] }
         try await openIfNeeded()
         guard let dbPool else { return [] }
-        // Use history to select directories active in each period; sum current conversation tokens by model
+        let iso8601 = ISO8601DateFormatter()
         let cal = Calendar.current
         let startOfDay = cal.startOfDay(for: now)
         let startOfWeek = cal.date(from: cal.dateComponents([.yearForWeekOfYear,.weekOfYear], from: now)) ?? startOfDay
         let startOfMonth = cal.date(from: cal.dateComponents([.year,.month], from: now)) ?? startOfDay
         let startOfYear = cal.date(from: cal.dateComponents([.year], from: now)) ?? startOfDay
-        let dayEpoch = Int64(startOfDay.timeIntervalSince1970)
-        let weekEpoch = Int64(startOfWeek.timeIntervalSince1970)
-        let monthEpoch = Int64(startOfMonth.timeIntervalSince1970)
-        let yearEpoch = Int64(startOfYear.timeIntervalSince1970)
-        guard let ct = schema.conversationsTable, let keyCol = schema.keyColumn, let valueCol = schema.valueColumn else { return [] }
+        let dayStr = iso8601.string(from: startOfDay)
+        let weekStr = iso8601.string(from: startOfWeek)
+        let monthStr = iso8601.string(from: startOfMonth)
+        let yearStr = iso8601.string(from: startOfYear)
         return try await dbPool.read { db in
-            // Precompute per-dir tokens + model from conversations
-            let convSQL = """
-            SELECT 
-              \(rawIdent(keyCol)) AS cwd,
-              COALESCE(json_extract(\(rawIdent(valueCol)),'$.model_info.model_id'), NULL) AS model_id,
-              COALESCE(length(json_extract(\(rawIdent(valueCol)),'$.history')),0) AS h_chars,
-              COALESCE(length(json_extract(\(rawIdent(valueCol)),'$.context_manager.context_files')),0) AS ctx_chars,
-              COALESCE(length(json_extract(\(rawIdent(valueCol)),'$.tool_manager')),0) AS tools_chars,
-              COALESCE(length(json_extract(\(rawIdent(valueCol)),'$.system_prompts')),0) AS sys_chars,
-              COALESCE(length(\(rawIdent(valueCol))),0) AS fallback_chars
-            FROM \(rawIdent(ct));
+            // Expand history entries with timestamps, filter by period boundaries
+            let sql = """
+            WITH hist AS (
+              SELECT
+                json_extract(c.value,'$.model_info.model_id') AS model_id,
+                COALESCE(
+                  json_extract(h.value,'$.assistant.timestamp'),
+                  json_extract(h.value,'$.assistant.created_at'),
+                  json_extract(h.value,'$.user.timestamp'),
+                  json_extract(h.value,'$.user.created_at')
+                ) AS ts,
+                CAST(((length(h.value)/4.0 + 5.0)/10.0) AS INTEGER)*10 AS tokens
+              FROM conversations c, json_each(
+                CASE
+                  WHEN json_type(json_extract(c.value,'$.history')) = 'array'
+                  THEN json_extract(c.value,'$.history')
+                  ELSE '[]'
+                END
+              ) h
+            )
+            SELECT model_id,
+              SUM(CASE WHEN ts >= ? THEN tokens ELSE 0 END) AS day_tokens,
+              SUM(CASE WHEN ts >= ? THEN tokens ELSE 0 END) AS week_tokens,
+              SUM(CASE WHEN ts >= ? THEN tokens ELSE 0 END) AS month_tokens,
+              SUM(CASE WHEN ts >= ? THEN tokens ELSE 0 END) AS year_tokens,
+              SUM(CASE WHEN ts >= ? THEN 1 ELSE 0 END) AS day_msgs,
+              SUM(CASE WHEN ts >= ? THEN 1 ELSE 0 END) AS week_msgs,
+              SUM(CASE WHEN ts >= ? THEN 1 ELSE 0 END) AS month_msgs
+            FROM hist
+            WHERE ts IS NOT NULL
+            GROUP BY model_id;
             """
-            let convRows = try Row.fetchAll(db, sql: convSQL)
-            var dirTokens: [String: (model: String?, tokens: Int)] = [:]
-            for r in convRows {
-                let cwd: String = r["cwd"] ?? ""
+            let args: [DatabaseValueConvertible] = [dayStr, weekStr, monthStr, yearStr, dayStr, weekStr, monthStr]
+            let rows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+            let defaultRate = 0.0025
+            var out: [PeriodByModel] = []
+            for r in rows {
                 let mid: String? = r["model_id"]
-                let h: Int = r["h_chars"] ?? 0
-                let cx: Int = r["ctx_chars"] ?? 0
-                let tl: Int = r["tools_chars"] ?? 0
-                let sy: Int = r["sys_chars"] ?? 0
-                let fb: Int = r["fallback_chars"] ?? 0
-                let br = TokenEstimator.Breakdown(historyChars: h, contextFilesChars: cx, toolsChars: tl, systemChars: sy, fallbackChars: fb)
-                dirTokens[cwd] = (mid, TokenEstimator.estimateTokens(breakdown: br))
+                let dTok: Int = r["day_tokens"] ?? 0
+                let wTok: Int = r["week_tokens"] ?? 0
+                let mTok: Int = r["month_tokens"] ?? 0
+                let yTok: Int = r["year_tokens"] ?? 0
+                let dMsg: Int = r["day_msgs"] ?? 0
+                let wMsg: Int = r["week_msgs"] ?? 0
+                let mMsg: Int = r["month_msgs"] ?? 0
+                out.append(PeriodByModel(
+                    modelId: mid,
+                    dayTokens: dTok, weekTokens: wTok, monthTokens: mTok, yearTokens: yTok,
+                    dayMessages: dMsg, weekMessages: wMsg, monthMessages: mMsg,
+                    dayCost: CostEstimator.estimateUSD(tokens: dTok, ratePer1k: defaultRate),
+                    weekCost: CostEstimator.estimateUSD(tokens: wTok, ratePer1k: defaultRate),
+                    monthCost: CostEstimator.estimateUSD(tokens: mTok, ratePer1k: defaultRate),
+                    yearCost: CostEstimator.estimateUSD(tokens: yTok, ratePer1k: defaultRate)
+                ))
             }
-            // Since history table is unused, consider all directories as potentially active
-            // In a real implementation, we'd need to track session timestamps differently
-            let allDirs = Set(dirTokens.keys)
-            let dDirs = allDirs  // All conversations considered for daily
-            let wDirs = allDirs  // All conversations considered for weekly  
-            let mDirs = allDirs  // All conversations considered for monthly
-            let yDirs = allDirs  // All conversations considered for yearly
-
-            // Aggregate by model
-            var byModel: [String?: (d:Int,w:Int,m:Int,y:Int, dm:Int, wm:Int, mm:Int)] = [:]
-            func add(model: String?, tokens: Int, to set: String) {
-                var rec = byModel[model] ?? (0,0,0,0,0,0,0)
-                switch set {
-                case "d": rec.0 += tokens; rec.4 += 1
-                case "w": rec.1 += tokens; rec.5 += 1
-                case "m": rec.2 += tokens; rec.6 += 1
-                case "y": rec.3 += tokens
-                default: break
-                }
-                byModel[model] = rec
-            }
-            for (cwd, val) in dirTokens {
-                if dDirs.contains(cwd) { add(model: val.model, tokens: val.tokens, to: "d") }
-                if wDirs.contains(cwd) { add(model: val.model, tokens: val.tokens, to: "w") }
-                if mDirs.contains(cwd) { add(model: val.model, tokens: val.tokens, to: "m") }
-                if yDirs.contains(cwd) { add(model: val.model, tokens: val.tokens, to: "y") }
-            }
-            // Calculate costs using default rate (this will be overridden by settings in UpdateCoordinator)
-            let defaultRate = 0.0025 // Default rate per 1k tokens
-            return byModel.map { (k,v) in
-                let dayCost = CostEstimator.estimateUSD(tokens: v.0, ratePer1k: defaultRate)
-                let weekCost = CostEstimator.estimateUSD(tokens: v.1, ratePer1k: defaultRate)
-                let monthCost = CostEstimator.estimateUSD(tokens: v.2, ratePer1k: defaultRate)
-                let yearCost = CostEstimator.estimateUSD(tokens: v.3, ratePer1k: defaultRate)
-                return PeriodByModel(
-                    modelId: k,
-                    dayTokens: v.0, weekTokens: v.1, monthTokens: v.2, yearTokens: v.3,
-                    dayMessages: v.4, weekMessages: v.5, monthMessages: v.6,
-                    dayCost: dayCost, weekCost: weekCost, monthCost: monthCost, yearCost: yearCost
-                )
-            }
+            return out
         }
     }
 
@@ -745,8 +801,6 @@ private func rawIdent(_ name: String) -> String {
 // MARK: - Token Estimation from JSON
 
 private func estimateTokensAndMessages(fromJSONString text: String) -> (tokens: Int, messages: Int, contextWindowTokens: Int?) {
-    // Rough token estimate: ~4 chars per token
-    let charsPerToken = 4.0
     var totalChars = 0
     var messages = 0
     var contextWindow: Int? = nil
@@ -755,7 +809,7 @@ private func estimateTokensAndMessages(fromJSONString text: String) -> (tokens: 
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         // fallback to raw length
         totalChars = text.count
-        return (Int(Double(totalChars) / charsPerToken), messages, contextWindow)
+        return (TokenEstimator.estimate(charCount: totalChars), messages, contextWindow)
     }
 
     if let modelInfo = json["model_info"] as? [String: Any], let cw = modelInfo["context_window_tokens"] as? Int { contextWindow = cw }
@@ -769,7 +823,7 @@ private func estimateTokensAndMessages(fromJSONString text: String) -> (tokens: 
         totalChars += deepStringCharacterCount(json)
     }
 
-    let tokens = Int((Double(totalChars) / charsPerToken).rounded())
+    let tokens = TokenEstimator.estimate(charCount: totalChars)
     return (tokens, messages, contextWindow)
 }
 

--- a/q-status-menubar/Sources/Core/TokenEstimator.swift
+++ b/q-status-menubar/Sources/Core/TokenEstimator.swift
@@ -27,6 +27,12 @@ public enum TokenEstimator {
         }
     }
 
+    /// Canonical single-contract estimator: chars → tokens.
+    /// All code paths must funnel through this for consistency.
+    public static func estimate(charCount: Int) -> Int {
+        return roundUpToNearest10(tokens: Double(charCount) / charsPerToken)
+    }
+
     private static func roundUpToNearest10(tokens: Double) -> Int {
         // Implements: (char/4 + 5) / 10 * 10 → round to nearest 10 (0.5 up)
         return Int(((tokens + 5.0) / 10.0).rounded(.down) * 10.0)
@@ -65,7 +71,7 @@ public enum TokenEstimator {
             totalChars = jsonString.count
         }
 
-        let tokens = Int((Double(totalChars) / charsPerToken).rounded())
+        let tokens = estimate(charCount: totalChars)
         return (tokens, messages, cwd, contextWindow, modelId)
     }
 

--- a/q-status-menubar/Sources/Core/UpdateCoordinator.swift
+++ b/q-status-menubar/Sources/Core/UpdateCoordinator.swift
@@ -237,11 +237,8 @@ public final class UpdateCoordinator: @unchecked Sendable {
             // Compute per-session cost with model-specific override when available
             let rate = self.settings.modelPricing[s.modelId ?? ""] ?? self.settings.costRatePer1kTokensUSD
             let cost = CostEstimator.estimateUSD(tokens: s.tokensUsed, ratePer1k: rate)
-            // Use 175k base for context usage percent (per Q CLI display)
-            let contextBase = 175_000
-            // Use PercentageCalculator for consistent percentage calculation
-            let usage175 = PercentageCalculator.calculateTokenPercentage(tokens: s.tokensUsed, limit: contextBase)
-            return SessionSummary(id: s.id, cwd: s.cwd, tokensUsed: s.tokensUsed, contextWindow: contextBase, usagePercent: usage175, messageCount: s.messageCount, lastActivity: s.lastActivity, state: state, internalRowID: s.internalRowID, hasCompactionIndicators: hasMarker, modelId: s.modelId, costUSD: cost)
+            // Preserve per-session context window from the data source
+            return SessionSummary(id: s.id, cwd: s.cwd, tokensUsed: s.tokensUsed, contextWindow: s.contextWindow, usagePercent: s.usagePercent, messageCount: s.messageCount, lastActivity: s.lastActivity, state: state, internalRowID: s.internalRowID, hasCompactionIndicators: hasMarker, modelId: s.modelId, costUSD: cost)
         }
         viewModel.sessions = mapped
         // Global totals for header
@@ -433,14 +430,10 @@ public final class UpdateCoordinator: @unchecked Sendable {
                     group.addTask { [weak self] in
                         guard let self else { return s }
                         if let details = try? await self.reader.fetchSessionDetail(key: s.id) {
-                            let ctxBase = 175_000
-                            let tokens = details.summary.tokensUsed
-                            // Use PercentageCalculator for consistent percentage calculation
-                            let usage = PercentageCalculator.calculateTokenPercentage(tokens: tokens, limit: ctxBase)
-                            let cwd = details.summary.cwd
-                            let rate = self.settings.modelPricing[details.summary.modelId ?? ""] ?? self.settings.costRatePer1kTokensUSD
-                            let cost = CostEstimator.estimateUSD(tokens: tokens, ratePer1k: rate)
-                            return SessionSummary(id: s.id, cwd: cwd, tokensUsed: tokens, contextWindow: ctxBase, usagePercent: usage, messageCount: details.summary.messageCount, lastActivity: details.summary.lastActivity, state: usage >= 100 ? .critical : (usage >= 90 ? .warn : .normal), internalRowID: s.internalRowID, hasCompactionIndicators: s.hasCompactionIndicators, modelId: details.summary.modelId, costUSD: cost)
+                            let d = details.summary
+                            let rate = self.settings.modelPricing[d.modelId ?? ""] ?? self.settings.costRatePer1kTokensUSD
+                            let cost = CostEstimator.estimateUSD(tokens: d.tokensUsed, ratePer1k: rate)
+                            return SessionSummary(id: s.id, cwd: d.cwd, tokensUsed: d.tokensUsed, contextWindow: d.contextWindow, usagePercent: d.usagePercent, messageCount: d.messageCount, lastActivity: d.lastActivity, state: d.state, internalRowID: s.internalRowID, hasCompactionIndicators: s.hasCompactionIndicators, modelId: d.modelId, costUSD: cost)
                         }
                         return s
                     }

--- a/q-status-menubar/Tests/CoreTests/BugFixTests.swift
+++ b/q-status-menubar/Tests/CoreTests/BugFixTests.swift
@@ -1,0 +1,329 @@
+import Testing
+import GRDB
+@testable import Core
+import Foundation
+
+// MARK: - Test helpers: in-memory QDBReader with seeded data
+
+private func makeTestDB(conversations: [(key: String, json: String)]) throws -> String {
+    let tmp = NSTemporaryDirectory() + "qstatus_test_\(UUID().uuidString).sqlite3"
+    let db = try DatabaseQueue(path: tmp)
+    try db.write { db in
+        try db.execute(sql: "CREATE TABLE conversations (key TEXT PRIMARY KEY, value TEXT)")
+        for conv in conversations {
+            try db.execute(sql: "INSERT INTO conversations (key, value) VALUES (?, ?)", arguments: [conv.key, conv.json])
+        }
+    }
+    return tmp
+}
+
+private func makeConversationJSON(
+    historyEntries: [(role: String, text: String, timestamp: String)],
+    modelId: String = "claude-3-sonnet",
+    contextWindowTokens: Int = 200_000,
+    cwd: String = "/test/project"
+) -> String {
+    var historyItems: [String] = []
+    for entry in historyEntries {
+        let item: String
+        if entry.role == "user" {
+            item = """
+            {"user":{"content":"\(entry.text)","timestamp":"\(entry.timestamp)","created_at":"\(entry.timestamp)"}}
+            """
+        } else {
+            item = """
+            {"assistant":{"content":"\(entry.text)","timestamp":"\(entry.timestamp)","created_at":"\(entry.timestamp)"}}
+            """
+        }
+        historyItems.append(item)
+    }
+    let historyJSON = "[" + historyItems.joined(separator: ",") + "]"
+    return """
+    {
+      "model_info": {"model_id": "\(modelId)", "context_window_tokens": \(contextWindowTokens)},
+      "env_context": {"env_state": {"current_working_directory": "\(cwd)"}},
+      "history": \(historyJSON),
+      "context_manager": {"context_files": []},
+      "tool_manager": {},
+      "system_prompts": "You are a helpful assistant."
+    }
+    """
+}
+
+private func iso(_ date: Date) -> String {
+    let f = ISO8601DateFormatter()
+    return f.string(from: date)
+}
+
+// MARK: - BUG-1: Period metrics are all-time totals
+
+@Suite("BUG-1: Period metrics filtering")
+struct Bug1PeriodMetricsTests {
+
+    @Test("Daily metrics exclude yesterday's data")
+    func dailyMetricsExcludeYesterdayData() async throws {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Calendar.current.startOfDay(for: now))!
+
+        let dbPath = try makeTestDB(conversations: [
+            ("old-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", String(repeating: "x", count: 4000), iso(yesterday)),
+                    ("assistant", String(repeating: "y", count: 4000), iso(yesterday))
+                ]
+            )),
+            ("today-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", String(repeating: "a", count: 400), iso(now)),
+                    ("assistant", String(repeating: "b", count: 400), iso(now))
+                ]
+            ))
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let reader = QDBReader(config: QDBConfig(dbPath: dbPath))
+        let periods = try await reader.fetchPeriodTokensByModel(now: now)
+
+        let totalDayTokens = periods.reduce(0) { $0 + $1.dayTokens }
+        let totalWeekTokens = periods.reduce(0) { $0 + $1.weekTokens }
+
+        #expect(totalDayTokens < totalWeekTokens,
+            "Daily tokens (\(totalDayTokens)) should be less than weekly tokens (\(totalWeekTokens)) when yesterday has more data")
+    }
+
+    @Test("Weekly metrics exclude last week's data")
+    func weeklyMetricsExcludeLastWeekData() async throws {
+        let now = Date()
+        let cal = Calendar.current
+        let twoWeeksAgo = cal.date(byAdding: .weekOfYear, value: -2, to: now)!
+
+        let dbPath = try makeTestDB(conversations: [
+            ("old-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", String(repeating: "x", count: 8000), iso(twoWeeksAgo)),
+                    ("assistant", String(repeating: "y", count: 8000), iso(twoWeeksAgo))
+                ]
+            )),
+            ("today-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", String(repeating: "a", count: 400), iso(now)),
+                    ("assistant", String(repeating: "b", count: 400), iso(now))
+                ]
+            ))
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let reader = QDBReader(config: QDBConfig(dbPath: dbPath))
+        let periods = try await reader.fetchPeriodTokensByModel(now: now)
+
+        let totalWeekTokens = periods.reduce(0) { $0 + $1.weekTokens }
+        let totalYearTokens = periods.reduce(0) { $0 + $1.yearTokens }
+
+        #expect(totalWeekTokens < totalYearTokens,
+            "Weekly tokens (\(totalWeekTokens)) should be less than yearly tokens (\(totalYearTokens)) when 2 weeks ago has more data")
+    }
+}
+
+// MARK: - BUG-2: Context window hardcoded to 175k
+
+@Suite("BUG-2: Context window preservation")
+struct Bug2ContextWindowTests {
+
+    @Test("Sessions preserve per-session context window from DB")
+    func preservesPerSessionContextWindow() async throws {
+        let now = Date()
+        let dbPath = try makeTestDB(conversations: [
+            ("session-200k", makeConversationJSON(
+                historyEntries: [
+                    ("user", "question", iso(now)),
+                    ("assistant", "answer", iso(now))
+                ],
+                contextWindowTokens: 200_000
+            )),
+            ("session-128k", makeConversationJSON(
+                historyEntries: [
+                    ("user", "question", iso(now)),
+                    ("assistant", "answer", iso(now))
+                ],
+                contextWindowTokens: 128_000
+            ))
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let reader = QDBReader(config: QDBConfig(dbPath: dbPath))
+        let sessions = try await reader.fetchSessions(limit: 50, offset: 0, groupByFolder: false, activeOnly: false)
+
+        let session200k = sessions.first { $0.id == "session-200k" }
+        let session128k = sessions.first { $0.id == "session-128k" }
+
+        #expect(session200k != nil)
+        #expect(session128k != nil)
+        #expect(session200k?.contextWindow == 200_000,
+            "200k session should have contextWindow=200000, got \(session200k?.contextWindow ?? -1)")
+        #expect(session128k?.contextWindow == 128_000,
+            "128k session should have contextWindow=128000, got \(session128k?.contextWindow ?? -1)")
+    }
+}
+
+// MARK: - BUG-3: Latest session = rowid, not activity
+
+@Suite("BUG-3: Latest session by activity")
+struct Bug3LatestSessionTests {
+
+    @Test("Latest session determined by activity timestamp, not rowid")
+    func latestSessionByActivityNotRowid() async throws {
+        let now = Date()
+        let oneHourAgo = now.addingTimeInterval(-3600)
+        let fiveMinutesAgo = now.addingTimeInterval(-300)
+
+        // First inserted (lower rowid) but MORE RECENT activity
+        // Second inserted (higher rowid) but OLDER activity
+        let dbPath = try makeTestDB(conversations: [
+            ("active-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", "recent question", iso(fiveMinutesAgo)),
+                    ("assistant", "recent answer", iso(fiveMinutesAgo))
+                ]
+            )),
+            ("stale-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", "old question", iso(oneHourAgo)),
+                    ("assistant", "old answer", iso(oneHourAgo))
+                ]
+            ))
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let reader = QDBReader(config: QDBConfig(dbPath: dbPath))
+        let usage = try await reader.fetchLatestUsage()
+
+        #expect(usage.conversationId == "active-session",
+            "Latest session should be determined by activity timestamp, not rowid. Got: \(usage.conversationId ?? "nil")")
+    }
+}
+
+// MARK: - BUG-4: Monthly message count has no month filter
+
+@Suite("BUG-4: Monthly message count filtering")
+struct Bug4MonthlyMessageCountTests {
+
+    @Test("Monthly message count only includes current month")
+    func monthlyMessageCountFiltersToCurrentMonth() async throws {
+        let now = Date()
+        let cal = Calendar.current
+        let twoMonthsAgo = cal.date(byAdding: .month, value: -2, to: now)!
+
+        let dbPath = try makeTestDB(conversations: [
+            ("old-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", "old msg 1", iso(twoMonthsAgo)),
+                    ("assistant", "old reply 1", iso(twoMonthsAgo)),
+                    ("user", "old msg 2", iso(twoMonthsAgo)),
+                    ("assistant", "old reply 2", iso(twoMonthsAgo)),
+                    ("user", "old msg 3", iso(twoMonthsAgo)),
+                    ("assistant", "old reply 3", iso(twoMonthsAgo)),
+                    ("user", "old msg 4", iso(twoMonthsAgo)),
+                    ("assistant", "old reply 4", iso(twoMonthsAgo)),
+                    ("user", "old msg 5", iso(twoMonthsAgo)),
+                    ("assistant", "old reply 5", iso(twoMonthsAgo))
+                ]
+            )),
+            ("current-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", "new msg", iso(now)),
+                    ("assistant", "new reply", iso(now))
+                ]
+            ))
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let reader = QDBReader(config: QDBConfig(dbPath: dbPath))
+        let monthlyCount = try await reader.fetchMonthlyMessageCount(now: now)
+
+        #expect(monthlyCount == 2,
+            "Monthly message count should only include current month. Got \(monthlyCount), expected 2")
+    }
+}
+
+// MARK: - BUG-5: Three divergent token estimators
+
+@Suite("BUG-5: Token estimator consistency")
+struct Bug5TokenEstimatorTests {
+
+    @Test("Golden case: 4000 chars = 1000 tokens")
+    func estimateGoldenCase4000chars() {
+        let result = TokenEstimator.estimate(charCount: 4000)
+        #expect(result == 1000, "4000 chars should yield exactly 1000 tokens. Got \(result)")
+    }
+
+    @Test("Golden case: 4001 chars = 1000 tokens")
+    func estimateGoldenCase4001chars() {
+        let result = TokenEstimator.estimate(charCount: 4001)
+        #expect(result == 1000, "4001 chars should yield 1000 tokens. Got \(result)")
+    }
+
+    @Test("All code paths produce consistent results")
+    func estimatorIsConsistentAcrossAllCodePaths() {
+        let charCount = 4000
+
+        // Path 1: The canonical estimate(charCount:) method
+        let canonical = TokenEstimator.estimate(charCount: charCount)
+
+        // Path 2: Via Breakdown with only fallback chars
+        let breakdown = TokenEstimator.Breakdown(
+            historyChars: 0, contextFilesChars: 0, toolsChars: 0, systemChars: 0,
+            fallbackChars: charCount
+        )
+        let viaBreakdown = TokenEstimator.estimateTokens(breakdown: breakdown)
+
+        // Path 3: Via the JSON slow-path estimate(from:)
+        let jsonStr = String(repeating: "x", count: charCount)
+        let viaJSON = TokenEstimator.estimate(from: jsonStr)
+
+        #expect(canonical == viaBreakdown,
+            "estimate(charCount:) (\(canonical)) should match estimateTokens(breakdown:) (\(viaBreakdown))")
+        #expect(canonical == viaJSON.tokens,
+            "estimate(charCount:) (\(canonical)) should match estimate(from:) (\(viaJSON.tokens))")
+    }
+}
+
+// MARK: - BUG-6: sessionCount(activeOnly:) ignores the parameter
+
+@Suite("BUG-6: sessionCount activeOnly filter")
+struct Bug6SessionCountTests {
+
+    @Test("activeOnly count matches activeOnly fetch")
+    func activeOnlyCountMatchesActiveOnlyFetch() async throws {
+        let now = Date()
+        let twoWeeksAgo = now.addingTimeInterval(-14 * 24 * 3600)
+
+        let dbPath = try makeTestDB(conversations: [
+            ("old-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", "old msg", iso(twoWeeksAgo)),
+                    ("assistant", "old reply", iso(twoWeeksAgo))
+                ]
+            )),
+            ("active-session", makeConversationJSON(
+                historyEntries: [
+                    ("user", "recent msg", iso(now)),
+                    ("assistant", "recent reply", iso(now))
+                ]
+            ))
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let reader = QDBReader(config: QDBConfig(dbPath: dbPath))
+
+        let totalCount = try await reader.sessionCount(activeOnly: false)
+        let activeCount = try await reader.sessionCount(activeOnly: true)
+
+        #expect(totalCount == 2, "Total count should be 2")
+        #expect(activeCount < totalCount,
+            "Active count (\(activeCount)) should be less than total (\(totalCount)) when old sessions exist")
+
+        let activeSessions = try await reader.fetchSessions(limit: 100, offset: 0, groupByFolder: false, activeOnly: true)
+        #expect(activeCount == activeSessions.count,
+            "sessionCount(activeOnly: true) (\(activeCount)) should match fetchSessions(activeOnly: true).count (\(activeSessions.count))")
+    }
+}

--- a/q-status-menubar/Tests/CoreTests/ClaudeCodeDataSourceTests.swift
+++ b/q-status-menubar/Tests/CoreTests/ClaudeCodeDataSourceTests.swift
@@ -1,24 +1,22 @@
 // ABOUTME: Unit tests for ClaudeCodeDataSource implementation
 // Tests JSONL parsing, session aggregation, and DataSource protocol compliance
 
-import XCTest
+import Testing
+import Foundation
 @testable import Core
 
-final class ClaudeCodeDataSourceTests: XCTestCase {
+@Suite("ClaudeCodeDataSource")
+struct ClaudeCodeDataSourceTests {
 
-    var dataSource: ClaudeCodeDataSource!
+    var dataSource: ClaudeCodeDataSource
 
-    override func setUp() async throws {
+    init() {
         dataSource = ClaudeCodeDataSource()
-    }
-
-    override func tearDown() {
-        dataSource = nil
     }
 
     // MARK: - JSONL Parsing Tests
 
-    func testClaudeUsageEntryDecoding() throws {
+    @Test func claudeUsageEntryDecoding() throws {
         let jsonString = """
         {
             "timestamp": "2024-01-15T10:30:00Z",
@@ -45,21 +43,21 @@ final class ClaudeCodeDataSourceTests: XCTestCase {
 
         let entry = try decoder.decode(ClaudeUsageEntry.self, from: data)
 
-        XCTAssertEqual(entry.timestamp, "2024-01-15T10:30:00Z")
-        XCTAssertEqual(entry.sessionId, "test-session-123")
-        XCTAssertEqual(entry.message.usage.input_tokens, 1000)
-        XCTAssertEqual(entry.message.usage.output_tokens, 500)
-        XCTAssertEqual(entry.message.usage.cache_creation_input_tokens, 100)
-        XCTAssertEqual(entry.message.usage.cache_read_input_tokens, 50)
-        XCTAssertEqual(entry.message.model, "claude-3-5-sonnet-20241022")
-        XCTAssertEqual(entry.message.id, "msg-123")
-        XCTAssertEqual(entry.costUSD, 0.0225)
-        XCTAssertEqual(entry.requestId, "req-456")
-        XCTAssertEqual(entry.cwd, "/Users/test/project")
-        XCTAssertEqual(entry.version, "0.7.23")
+        #expect(entry.timestamp == "2024-01-15T10:30:00Z")
+        #expect(entry.sessionId == "test-session-123")
+        #expect(entry.message.usage.input_tokens == 1000)
+        #expect(entry.message.usage.output_tokens == 500)
+        #expect(entry.message.usage.cache_creation_input_tokens == 100)
+        #expect(entry.message.usage.cache_read_input_tokens == 50)
+        #expect(entry.message.model == "claude-3-5-sonnet-20241022")
+        #expect(entry.message.id == "msg-123")
+        #expect(entry.costUSD == 0.0225)
+        #expect(entry.requestId == "req-456")
+        #expect(entry.cwd == "/Users/test/project")
+        #expect(entry.version == "0.7.23")
     }
 
-    func testClaudeUsageEntryDecodingWithOptionalFields() throws {
+    @Test func claudeUsageEntryDecodingWithOptionalFields() throws {
         let jsonString = """
         {
             "timestamp": "2024-01-15T10:30:00Z",
@@ -77,23 +75,23 @@ final class ClaudeCodeDataSourceTests: XCTestCase {
 
         let entry = try decoder.decode(ClaudeUsageEntry.self, from: data)
 
-        XCTAssertEqual(entry.timestamp, "2024-01-15T10:30:00Z")
-        XCTAssertNil(entry.sessionId)
-        XCTAssertEqual(entry.message.usage.input_tokens, 1000)
-        XCTAssertEqual(entry.message.usage.output_tokens, 500)
-        XCTAssertNil(entry.message.usage.cache_creation_input_tokens)
-        XCTAssertNil(entry.message.usage.cache_read_input_tokens)
-        XCTAssertNil(entry.message.model)
-        XCTAssertNil(entry.message.id)
-        XCTAssertNil(entry.costUSD)
-        XCTAssertNil(entry.requestId)
-        XCTAssertNil(entry.cwd)
-        XCTAssertNil(entry.version)
+        #expect(entry.timestamp == "2024-01-15T10:30:00Z")
+        #expect(entry.sessionId == nil)
+        #expect(entry.message.usage.input_tokens == 1000)
+        #expect(entry.message.usage.output_tokens == 500)
+        #expect(entry.message.usage.cache_creation_input_tokens == nil)
+        #expect(entry.message.usage.cache_read_input_tokens == nil)
+        #expect(entry.message.model == nil)
+        #expect(entry.message.id == nil)
+        #expect(entry.costUSD == nil)
+        #expect(entry.requestId == nil)
+        #expect(entry.cwd == nil)
+        #expect(entry.version == nil)
     }
 
     // MARK: - Token Calculation Tests
 
-    func testTokenUsageTotalCalculation() {
+    @Test func tokenUsageTotalCalculation() {
         let usage = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -101,10 +99,10 @@ final class ClaudeCodeDataSourceTests: XCTestCase {
             cache_read_input_tokens: 50
         )
 
-        XCTAssertEqual(usage.totalTokens, 1650)
+        #expect(usage.totalTokens == 1650)
     }
 
-    func testTokenUsageTotalWithNilOptionals() {
+    @Test func tokenUsageTotalWithNilOptionals() {
         let usage = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -112,12 +110,12 @@ final class ClaudeCodeDataSourceTests: XCTestCase {
             cache_read_input_tokens: nil
         )
 
-        XCTAssertEqual(usage.totalTokens, 1500)
+        #expect(usage.totalTokens == 1500)
     }
 
     // MARK: - Session Aggregation Tests
 
-    func testSessionTotalTokensCalculation() {
+    @Test func sessionTotalTokensCalculation() {
         let session = ClaudeSession(
             id: "test-session",
             startTime: Date(),
@@ -134,36 +132,36 @@ final class ClaudeCodeDataSourceTests: XCTestCase {
             messageCount: 1
         )
 
-        XCTAssertEqual(session.totalTokens, 1650)
+        #expect(session.totalTokens == 1650)
     }
 
     // MARK: - DataSource Protocol Tests
 
-    func testDataSourceInitialization() async throws {
+    @Test func dataSourceInitialization() async throws {
         // Test that the data source can be opened without errors
         // This will fail if no Claude data directories exist, which is expected in test environment
         do {
             try await dataSource.openIfNeeded()
         } catch {
             // Expected in test environment without actual Claude data
-            XCTAssertNotNil(error)
+            #expect(error != nil)
         }
     }
 
-    func testFetchLatestUsageWithNoData() async throws {
+    @Test func fetchLatestUsageWithNoData() async throws {
         // When no data is available, should return empty snapshot
         do {
             let usage = try await dataSource.fetchLatestUsage(window: nil)
-            XCTAssertEqual(usage.tokensUsed, 0)
-            XCTAssertEqual(usage.messageCount, 0)
-            XCTAssertNil(usage.conversationId)
+            #expect(usage.tokensUsed == 0)
+            #expect(usage.messageCount == 0)
+            #expect(usage.conversationId == nil)
         } catch {
             // Expected if no Claude directories exist
-            XCTAssertNotNil(error)
+            #expect(error != nil)
         }
     }
 
-    func testFetchSessionsWithNoData() async throws {
+    @Test func fetchSessionsWithNoData() async throws {
         // When no data is available, should return empty array
         do {
             let sessions = try await dataSource.fetchSessions(
@@ -172,41 +170,41 @@ final class ClaudeCodeDataSourceTests: XCTestCase {
                 groupByFolder: false,
                 activeOnly: false
             )
-            XCTAssertEqual(sessions.count, 0)
+            #expect(sessions.count == 0)
         } catch {
             // Expected if no Claude directories exist
-            XCTAssertNotNil(error)
+            #expect(error != nil)
         }
     }
 
-    func testSessionCountWithNoData() async throws {
+    @Test func sessionCountWithNoData() async throws {
         // When no data is available, should return 0
         do {
             let count = try await dataSource.sessionCount(activeOnly: false)
-            XCTAssertEqual(count, 0)
+            #expect(count == 0)
         } catch {
             // Expected if no Claude directories exist
-            XCTAssertNotNil(error)
+            #expect(error != nil)
         }
     }
 
-    func testFetchGlobalMetricsWithNoData() async throws {
+    @Test func fetchGlobalMetricsWithNoData() async throws {
         // When no data is available, should return empty metrics
         do {
             let metrics = try await dataSource.fetchGlobalMetrics(limitForTop: 5)
-            XCTAssertEqual(metrics.totalSessions, 0)
-            XCTAssertEqual(metrics.totalTokens, 0)
-            XCTAssertEqual(metrics.sessionsNearLimit, 0)
-            XCTAssertEqual(metrics.topHeavySessions.count, 0)
+            #expect(metrics.totalSessions == 0)
+            #expect(metrics.totalTokens == 0)
+            #expect(metrics.sessionsNearLimit == 0)
+            #expect(metrics.topHeavySessions.count == 0)
         } catch {
             // Expected if no Claude directories exist
-            XCTAssertNotNil(error)
+            #expect(error != nil)
         }
     }
 
     // MARK: - Date Parsing Tests
 
-    func testISO8601DateParsing() throws {
+    @Test func iso8601DateParsing() throws {
         let jsonString = """
         {
             "timestamp": "2024-01-15T10:30:00Z",
@@ -223,15 +221,15 @@ final class ClaudeCodeDataSourceTests: XCTestCase {
         let decoder = JSONDecoder()
         let entry = try decoder.decode(ClaudeUsageEntry.self, from: data)
 
-        XCTAssertNotNil(entry.date)
+        #expect(entry.date != nil)
 
         // Verify the date components
         let calendar = Calendar(identifier: .gregorian)
         let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: entry.date!)
 
-        XCTAssertEqual(components.year, 2024)
-        XCTAssertEqual(components.month, 1)
-        XCTAssertEqual(components.day, 15)
+        #expect(components.year == 2024)
+        #expect(components.month == 1)
+        #expect(components.day == 15)
     }
 
     // MARK: - Sample Data Creation Helpers

--- a/q-status-menubar/Tests/CoreTests/ClaudeCostCalculatorTests.swift
+++ b/q-status-menubar/Tests/CoreTests/ClaudeCostCalculatorTests.swift
@@ -1,14 +1,16 @@
 // ABOUTME: Comprehensive tests for ClaudeCostCalculator matching ccusage logic
 // Tests cost calculation modes, model pricing, cache tokens, and edge cases
 
-import XCTest
+import Testing
+import Foundation
 @testable import Core
 
-final class ClaudeCostCalculatorTests: XCTestCase {
+@Suite("ClaudeCostCalculator")
+struct ClaudeCostCalculatorTests {
 
     // MARK: - Basic Cost Calculation Tests
 
-    func testCostCalculationSonnet() {
+    @Test func costCalculationSonnet() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -25,10 +27,10 @@ final class ClaudeCostCalculatorTests: XCTestCase {
 
         // Expected: (1000 * 3/1M) + (500 * 15/1M) + (100 * 3.75/1M) + (200 * 0.3/1M)
         // = 0.003 + 0.0075 + 0.000375 + 0.00006 = 0.010935
-        XCTAssertEqual(cost, 0.010935, accuracy: 0.000001)
+        #expect(abs(cost - 0.010935) < 0.000001)
     }
 
-    func testCostCalculationOpus() {
+    @Test func costCalculationOpus() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -44,10 +46,10 @@ final class ClaudeCostCalculatorTests: XCTestCase {
         )
 
         // Expected: (1000 * 15/1M) + (500 * 75/1M) = 0.015 + 0.0375 = 0.0525
-        XCTAssertEqual(cost, 0.0525, accuracy: 0.000001)
+        #expect(abs(cost - 0.0525) < 0.000001)
     }
 
-    func testCostCalculationHaiku() {
+    @Test func costCalculationHaiku() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 10000,
             output_tokens: 5000,
@@ -63,10 +65,10 @@ final class ClaudeCostCalculatorTests: XCTestCase {
         )
 
         // Expected: (10000 * 0.25/1M) + (5000 * 1.25/1M) = 0.0025 + 0.00625 = 0.00875
-        XCTAssertEqual(cost, 0.00875, accuracy: 0.000001)
+        #expect(abs(cost - 0.00875) < 0.000001)
     }
 
-    func testCostCalculationNewHaiku() {
+    @Test func costCalculationNewHaiku() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 10000,
             output_tokens: 5000,
@@ -82,12 +84,12 @@ final class ClaudeCostCalculatorTests: XCTestCase {
         )
 
         // Expected: (10000 * 1/1M) + (5000 * 5/1M) = 0.01 + 0.025 = 0.035
-        XCTAssertEqual(cost, 0.035, accuracy: 0.000001)
+        #expect(abs(cost - 0.035) < 0.000001)
     }
 
     // MARK: - Cost Mode Tests
 
-    func testCostModeDisplay() {
+    @Test func costModeDisplay() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -102,7 +104,7 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             mode: .display,
             existingCost: 0.123
         )
-        XCTAssertEqual(cost, 0.123)
+        #expect(cost == 0.123)
 
         // Without existing cost
         let costNoExisting = ClaudeCostCalculator.calculateCost(
@@ -111,10 +113,10 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             mode: .display,
             existingCost: nil
         )
-        XCTAssertEqual(costNoExisting, 0.0)
+        #expect(costNoExisting == 0.0)
     }
 
-    func testCostModeAuto() {
+    @Test func costModeAuto() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -129,7 +131,7 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             mode: .auto,
             existingCost: 0.123
         )
-        XCTAssertEqual(cost, 0.123)
+        #expect(cost == 0.123)
 
         // Without existing cost - should calculate
         let costCalculated = ClaudeCostCalculator.calculateCost(
@@ -138,7 +140,7 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             mode: .auto,
             existingCost: nil
         )
-        XCTAssertEqual(costCalculated, 0.0105, accuracy: 0.000001)
+        #expect(abs(costCalculated - 0.0105) < 0.000001)
 
         // With zero existing cost - should calculate
         let costZero = ClaudeCostCalculator.calculateCost(
@@ -147,10 +149,10 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             mode: .auto,
             existingCost: 0.0
         )
-        XCTAssertEqual(costZero, 0.0105, accuracy: 0.000001)
+        #expect(abs(costZero - 0.0105) < 0.000001)
     }
 
-    func testCostModeCalculate() {
+    @Test func costModeCalculate() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -165,12 +167,12 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             mode: .calculate,
             existingCost: 999.99
         )
-        XCTAssertEqual(cost, 0.0105, accuracy: 0.000001)
+        #expect(abs(cost - 0.0105) < 0.000001)
     }
 
     // MARK: - Model Name Normalization Tests
 
-    func testModelNameWithProviderPrefix() {
+    @Test func modelNameWithProviderPrefix() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -188,11 +190,11 @@ final class ClaudeCostCalculatorTests: XCTestCase {
                 mode: .calculate,
                 existingCost: nil
             )
-            XCTAssertEqual(cost, 0.0105, accuracy: 0.000001, "Failed for prefix: \(prefix)")
+            #expect(abs(cost - 0.0105) < 0.000001, "Failed for prefix: \(prefix)")
         }
     }
 
-    func testModelNameVariations() {
+    @Test func modelNameVariations() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -215,11 +217,11 @@ final class ClaudeCostCalculatorTests: XCTestCase {
                 mode: .calculate,
                 existingCost: nil
             )
-            XCTAssertEqual(cost, 0.0105, accuracy: 0.000001, "Failed for model: \(model)")
+            #expect(abs(cost - 0.0105) < 0.000001, "Failed for model: \(model)")
         }
     }
 
-    func testUnknownModelFallback() {
+    @Test func unknownModelFallback() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -235,12 +237,12 @@ final class ClaudeCostCalculatorTests: XCTestCase {
         )
 
         // Should use default model pricing (sonnet)
-        XCTAssertEqual(cost, 0.0105, accuracy: 0.000001)
+        #expect(abs(cost - 0.0105) < 0.000001)
     }
 
     // MARK: - Cache Token Tests
 
-    func testCacheTokenCosts() {
+    @Test func cacheTokenCosts() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 0,
             output_tokens: 0,
@@ -258,10 +260,10 @@ final class ClaudeCostCalculatorTests: XCTestCase {
         // Cache creation: 1000 * 3.75/1M = 0.00375
         // Cache read: 1000 * 0.3/1M = 0.0003
         // Total: 0.00405
-        XCTAssertEqual(cost, 0.00405, accuracy: 0.000001)
+        #expect(abs(cost - 0.00405) < 0.000001)
     }
 
-    func testMixedTokenTypes() {
+    @Test func mixedTokenTypes() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 2000,
@@ -281,12 +283,12 @@ final class ClaudeCostCalculatorTests: XCTestCase {
         // Cache creation: 500 * 3.75/1M = 0.001875
         // Cache read: 1500 * 0.3/1M = 0.00045
         // Total: 0.035325
-        XCTAssertEqual(cost, 0.035325, accuracy: 0.000001)
+        #expect(abs(cost - 0.035325) < 0.000001)
     }
 
     // MARK: - Edge Cases
 
-    func testZeroTokens() {
+    @Test func zeroTokens() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 0,
             output_tokens: 0,
@@ -301,10 +303,10 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             existingCost: nil
         )
 
-        XCTAssertEqual(cost, 0.0)
+        #expect(cost == 0.0)
     }
 
-    func testVeryLargeTokenCounts() {
+    @Test func veryLargeTokenCounts() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1_000_000,
             output_tokens: 500_000,
@@ -324,44 +326,44 @@ final class ClaudeCostCalculatorTests: XCTestCase {
         // Cache creation: 100K * 3.75/1M = 0.375
         // Cache read: 200K * 0.3/1M = 0.06
         // Total: 10.935
-        XCTAssertEqual(cost, 10.935, accuracy: 0.000001)
+        #expect(abs(cost - 10.935) < 0.000001)
     }
 
     // MARK: - Formatting Tests
 
-    func testCostFormatting() {
-        XCTAssertEqual(ClaudeCostCalculator.formatCost(0.0001), "$0.0001")
-        XCTAssertEqual(ClaudeCostCalculator.formatCost(0.00001), "$0.0000")
-        XCTAssertEqual(ClaudeCostCalculator.formatCost(0.01), "$0.01")
-        XCTAssertEqual(ClaudeCostCalculator.formatCost(1.234567), "$1.2346")
-        XCTAssertEqual(ClaudeCostCalculator.formatCost(1234.56), "$1,234.56")
+    @Test func costFormatting() {
+        #expect(ClaudeCostCalculator.formatCost(0.0001) == "$0.0001")
+        #expect(ClaudeCostCalculator.formatCost(0.00001) == "$0.0000")
+        #expect(ClaudeCostCalculator.formatCost(0.01) == "$0.01")
+        #expect(ClaudeCostCalculator.formatCost(1.234567) == "$1.2346")
+        #expect(ClaudeCostCalculator.formatCost(1234.56) == "$1,234.56")
     }
 
     // MARK: - Model Pricing Tests
 
-    func testGetModelPricing() {
+    @Test func getModelPricing() {
         let pricing = ClaudeCostCalculator.getModelPricing(for: "claude-3-5-sonnet")
 
-        XCTAssertEqual(pricing.inputCostPerToken ?? 0, 0.000003, accuracy: 0.0000000001)
-        XCTAssertEqual(pricing.outputCostPerToken ?? 0, 0.000015, accuracy: 0.0000000001)
-        XCTAssertEqual(pricing.cacheCreationCostPerToken ?? 0, 0.00000375, accuracy: 0.0000000001)
-        XCTAssertEqual(pricing.cacheReadCostPerToken ?? 0, 0.0000003, accuracy: 0.0000000001)
-        XCTAssertEqual(pricing.maxTokens, 200_000)
+        #expect(abs((pricing.inputCostPerToken ?? 0) - 0.000003) < 0.0000000001)
+        #expect(abs((pricing.outputCostPerToken ?? 0) - 0.000015) < 0.0000000001)
+        #expect(abs((pricing.cacheCreationCostPerToken ?? 0) - 0.00000375) < 0.0000000001)
+        #expect(abs((pricing.cacheReadCostPerToken ?? 0) - 0.0000003) < 0.0000000001)
+        #expect(pricing.maxTokens == 200_000)
     }
 
-    func testAvailableModels() {
+    @Test func availableModels() {
         let models = ClaudeCostCalculator.availableModels()
 
-        XCTAssertTrue(models.contains("claude-3-5-sonnet"))
-        XCTAssertTrue(models.contains("claude-3-opus"))
-        XCTAssertTrue(models.contains("claude-3-haiku"))
-        XCTAssertTrue(models.contains("claude-3-5-haiku"))
-        XCTAssertTrue(models.sorted() == models) // Should be sorted
+        #expect(models.contains("claude-3-5-sonnet"))
+        #expect(models.contains("claude-3-opus"))
+        #expect(models.contains("claude-3-haiku"))
+        #expect(models.contains("claude-3-5-haiku"))
+        #expect(models.sorted() == models) // Should be sorted
     }
 
     // MARK: - JSON Loading Tests
 
-    func testLoadPricingFromJSON() throws {
+    @Test func loadPricingFromJSON() throws {
         // Create a temporary JSON file
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_prices.json")
         let testPricing = """
@@ -381,15 +383,15 @@ final class ClaudeCostCalculatorTests: XCTestCase {
 
         let loadedPricing = try ClaudeCostCalculator.loadPricingFromJSON(at: tempURL)
 
-        XCTAssertNotNil(loadedPricing["test-model"])
-        XCTAssertEqual(loadedPricing["test-model"]?.inputCostPerToken, 0.001)
-        XCTAssertEqual(loadedPricing["test-model"]?.outputCostPerToken, 0.002)
-        XCTAssertEqual(loadedPricing["test-model"]?.maxTokens, 100000)
+        #expect(loadedPricing["test-model"] != nil)
+        #expect(loadedPricing["test-model"]?.inputCostPerToken == 0.001)
+        #expect(loadedPricing["test-model"]?.outputCostPerToken == 0.002)
+        #expect(loadedPricing["test-model"]?.maxTokens == 100000)
     }
 
     // MARK: - Extension Tests
 
-    func testTokenUsageExtension() {
+    @Test func tokenUsageExtension() {
         let tokens = ClaudeTokenUsage(
             input_tokens: 1000,
             output_tokens: 500,
@@ -403,28 +405,6 @@ final class ClaudeCostCalculatorTests: XCTestCase {
             existingCost: nil
         )
 
-        XCTAssertEqual(cost, 0.0105, accuracy: 0.000001)
-    }
-
-    // MARK: - Performance Tests
-
-    func testPerformanceCalculateCost() {
-        let tokens = ClaudeTokenUsage(
-            input_tokens: 1000,
-            output_tokens: 500,
-            cache_creation_input_tokens: 100,
-            cache_read_input_tokens: 200
-        )
-
-        measure {
-            for _ in 0..<1000 {
-                _ = ClaudeCostCalculator.calculateCost(
-                    tokens: tokens,
-                    model: "claude-3-5-sonnet",
-                    mode: .calculate,
-                    existingCost: nil
-                )
-            }
-        }
+        #expect(abs(cost - 0.0105) < 0.000001)
     }
 }

--- a/q-status-menubar/Tests/CoreTests/DataSourceProtocolTests.swift
+++ b/q-status-menubar/Tests/CoreTests/DataSourceProtocolTests.swift
@@ -1,21 +1,23 @@
 // ABOUTME: Tests for the DataSource protocol abstraction
 // Verifies that QDBReader correctly conforms to the protocol and that the abstraction works
 
-import XCTest
+import Testing
+import Foundation
 @testable import Core
 
-final class DataSourceProtocolTests: XCTestCase {
+@Suite("DataSourceProtocol")
+struct DataSourceProtocolTests {
 
-    func testQDBReaderConformsToDataSource() {
+    @Test func qdbReaderConformsToDataSource() {
         // This test verifies at compile-time that QDBReader conforms to DataSource
         // If this compiles, the protocol conformance is correct
         let _: any DataSource = QDBReader()
 
         // The fact that this compiles proves QDBReader conforms to DataSource
-        XCTAssertTrue(true, "QDBReader successfully conforms to DataSource protocol")
+        #expect(true, "QDBReader successfully conforms to DataSource protocol")
     }
 
-    func testDataSourceCanBeUsedAsAbstraction() async throws {
+    @Test func dataSourceCanBeUsedAsAbstraction() async throws {
         // Create a QDBReader through the protocol
         let dataSource: any DataSource = QDBReader()
 
@@ -48,10 +50,10 @@ final class DataSourceProtocolTests: XCTestCase {
             settings: settings
         )
 
-        XCTAssertNotNil(coordinator, "UpdateCoordinator accepts DataSource protocol")
+        #expect(coordinator != nil, "UpdateCoordinator accepts DataSource protocol")
     }
 
-    func testDefaultImplementations() async throws {
+    @Test func defaultImplementations() async throws {
         // Test that default implementations work
         let dataSource: any DataSource = QDBReader()
 
@@ -67,7 +69,7 @@ final class DataSourceProtocolTests: XCTestCase {
             print("Default implementations work but database access failed (expected): \(error)")
         }
 
-        XCTAssertTrue(true, "Default implementations are accessible")
+        #expect(true, "Default implementations are accessible")
     }
 }
 
@@ -179,19 +181,20 @@ actor MockDataSource: DataSource {
     }
 }
 
-final class MockDataSourceTests: XCTestCase {
+@Suite("MockDataSource")
+struct MockDataSourceTests {
 
-    func testMockDataSourceWorks() async throws {
+    @Test func mockDataSourceWorks() async throws {
         let mock: any DataSource = MockDataSource()
 
         // Test that mock implements all required methods
         try await mock.openIfNeeded()
 
         let version = try await mock.dataVersion()
-        XCTAssertEqual(version, 1)
+        #expect(version == 1)
 
         let usage = try await mock.fetchLatestUsage(window: nil)
-        XCTAssertEqual(usage.tokensUsed, 1000)
+        #expect(usage.tokensUsed == 1000)
 
         let sessions = try await mock.fetchSessions(
             limit: 10,
@@ -199,19 +202,19 @@ final class MockDataSourceTests: XCTestCase {
             groupByFolder: false,
             activeOnly: false
         )
-        XCTAssertEqual(sessions.count, 1)
+        #expect(sessions.count == 1)
 
         let detail = try await mock.fetchSessionDetail(key: "test")
-        XCTAssertNotNil(detail)
+        #expect(detail != nil)
 
         let count = try await mock.sessionCount(activeOnly: false)
-        XCTAssertEqual(count, 10)
+        #expect(count == 10)
 
         let metrics = try await mock.fetchGlobalMetrics(limitForTop: 5)
-        XCTAssertEqual(metrics.totalSessions, 10)
+        #expect(metrics.totalSessions == 10)
     }
 
-    func testUpdateCoordinatorWithMock() async throws {
+    @Test func updateCoordinatorWithMock() async throws {
         let mock: any DataSource = MockDataSource()
         let metrics = MetricsCalculator()
         let settings = SettingsStore()
@@ -232,6 +235,6 @@ final class MockDataSourceTests: XCTestCase {
         coordinator.stop()
 
         // Verify it initialized correctly
-        XCTAssertNotNil(coordinator.viewModel)
+        #expect(coordinator.viewModel != nil)
     }
 }

--- a/q-status-menubar/Tests/CoreTests/MetricsCalculatorTests.swift
+++ b/q-status-menubar/Tests/CoreTests/MetricsCalculatorTests.swift
@@ -1,12 +1,12 @@
-import XCTest
+import Testing
 @testable import Core
 
-final class MetricsCalculatorTests: XCTestCase {
-    func testUsagePercent() {
+@Suite("MetricsCalculator")
+struct MetricsCalculatorTests {
+    @Test func usagePercent() {
         let calc = MetricsCalculator()
-        XCTAssertEqual(calc.usagePercent(used: 2000, limit: 4000), 50.0)
-        XCTAssertEqual(calc.usagePercent(used: 0, limit: 0), 0.0)
-        XCTAssertEqual(calc.usagePercent(used: 5000, limit: 4000), 100.0)
+        #expect(calc.usagePercent(used: 2000, limit: 4000) == 50.0)
+        #expect(calc.usagePercent(used: 0, limit: 0) == 0.0)
+        #expect(calc.usagePercent(used: 5000, limit: 4000) == 100.0)
     }
 }
-

--- a/q-status-menubar/Tests/CoreTests/PercentageCalculatorNoSessionTest.swift
+++ b/q-status-menubar/Tests/CoreTests/PercentageCalculatorNoSessionTest.swift
@@ -1,12 +1,14 @@
 // ABOUTME: Test to verify PercentageCalculator returns 0% when no active session exists
 // This test ensures the fix for the ccusage/qstatus discrepancy is working correctly
 
-import XCTest
+import Testing
+import Foundation
 @testable import Core
 
-class PercentageCalculatorNoSessionTest: XCTestCase {
+@Suite("PercentageCalculatorNoSession")
+struct PercentageCalculatorNoSessionTests {
 
-    func testNoActiveSessionReturnsZeroPercent() {
+    @Test func noActiveSessionReturnsZeroPercent() {
         // Test with no active session and monthly data available
         let monthlyData = (cost: 20.0, limit: 18.0)  // Cost exceeds limit
 
@@ -17,10 +19,10 @@ class PercentageCalculatorNoSessionTest: XCTestCase {
         )
 
         // Should return 0% instead of calculating monthly percentage
-        XCTAssertEqual(percentage, 0, "Should return 0% when no active session exists")
+        #expect(percentage == 0, "Should return 0% when no active session exists")
     }
 
-    func testNoActiveSessionNoMonthlyDataReturnsZeroPercent() {
+    @Test func noActiveSessionNoMonthlyDataReturnsZeroPercent() {
         // Test with no active session and no monthly data
         let percentage = PercentageCalculator.calculateCriticalPercentage(
             activeSession: nil,
@@ -29,10 +31,10 @@ class PercentageCalculatorNoSessionTest: XCTestCase {
         )
 
         // Should return 0%
-        XCTAssertEqual(percentage, 0, "Should return 0% when no active session and no monthly data")
+        #expect(percentage == 0, "Should return 0% when no active session and no monthly data")
     }
 
-    func testActiveSessionWithoutBlockUsesSessionData() {
+    @Test func activeSessionWithoutBlockUsesSessionData() {
         // Create a mock active session without a block
         let activeSession = ActiveSessionData(
             sessionId: "test-session",
@@ -61,6 +63,6 @@ class PercentageCalculatorNoSessionTest: XCTestCase {
         )
 
         // Should calculate based on session data, not return 0
-        XCTAssertGreaterThan(percentage, 0, "Should calculate percentage when active session exists")
+        #expect(percentage > 0, "Should calculate percentage when active session exists")
     }
 }

--- a/q-status-menubar/Tests/CoreTests/PercentageCalculatorTests.swift
+++ b/q-status-menubar/Tests/CoreTests/PercentageCalculatorTests.swift
@@ -1,14 +1,15 @@
 // ABOUTME: Tests for PercentageCalculator ensuring consistent percentage calculations across the app
 // Tests cover all percentage calculation methods including Claude token limit calculations
 
-import XCTest
+import Testing
 @testable import Core
 
-final class PercentageCalculatorTests: XCTestCase {
+@Suite("PercentageCalculator")
+struct PercentageCalculatorTests {
 
     // MARK: - Token Percentage Tests
 
-    func testCalculateTokenPercentage_withValidInputs() {
+    @Test func calculateTokenPercentage_withValidInputs() {
         // Test token percentage calculation with valid inputs
         let currentTokens = 50000
         let tokenLimit = 200000
@@ -18,33 +19,33 @@ final class PercentageCalculatorTests: XCTestCase {
             limit: tokenLimit
         )
 
-        XCTAssertEqual(percentage, 25.0, accuracy: 0.01,
-                      "Should calculate 25% for 50K tokens out of 200K limit")
+        #expect(abs(percentage - 25.0) < 0.01,
+               "Should calculate 25% for 50K tokens out of 200K limit")
     }
 
-    func testCalculateTokenPercentage_withZeroTokens() {
+    @Test func calculateTokenPercentage_withZeroTokens() {
         // Test with zero current tokens
         let percentage = PercentageCalculator.calculateTokenPercentage(
             tokens: 0,
             limit: 200000
         )
 
-        XCTAssertEqual(percentage, 0.0, accuracy: 0.01,
-                      "Should return 0% for zero tokens")
+        #expect(abs(percentage - 0.0) < 0.01,
+               "Should return 0% for zero tokens")
     }
 
-    func testCalculateTokenPercentage_withZeroLimit() {
+    @Test func calculateTokenPercentage_withZeroLimit() {
         // Test with zero limit (should return 0 to avoid division by zero)
         let percentage = PercentageCalculator.calculateTokenPercentage(
             tokens: 50000,
             limit: 0
         )
 
-        XCTAssertEqual(percentage, 0.0, accuracy: 0.01,
-                      "Should return 0% for zero limit to avoid division by zero")
+        #expect(abs(percentage - 0.0) < 0.01,
+               "Should return 0% for zero limit to avoid division by zero")
     }
 
-    func testCalculateTokenPercentage_atLimit() {
+    @Test func calculateTokenPercentage_atLimit() {
         // Test when current tokens equals the limit
         let currentTokens = 200000
         let tokenLimit = 200000
@@ -54,11 +55,11 @@ final class PercentageCalculatorTests: XCTestCase {
             limit: tokenLimit
         )
 
-        XCTAssertEqual(percentage, 100.0, accuracy: 0.01,
-                      "Should return 100% when at token limit")
+        #expect(abs(percentage - 100.0) < 0.01,
+               "Should return 100% when at token limit")
     }
 
-    func testCalculateTokenPercentage_overLimit_capped() {
+    @Test func calculateTokenPercentage_overLimit_capped() {
         // Test when current tokens exceeds the limit with capping (default behavior)
         let currentTokens = 250000
         let tokenLimit = 200000
@@ -68,11 +69,11 @@ final class PercentageCalculatorTests: XCTestCase {
             limit: tokenLimit
         )
 
-        XCTAssertEqual(percentage, 100.0, accuracy: 0.01,
-                      "Should cap at 100% when exceeding token limit")
+        #expect(abs(percentage - 100.0) < 0.01,
+               "Should cap at 100% when exceeding token limit")
     }
 
-    func testCalculateTokenPercentage_overLimit_uncapped() {
+    @Test func calculateTokenPercentage_overLimit_uncapped() {
         // Test when current tokens exceeds the limit without capping
         let currentTokens = 250000
         let tokenLimit = 200000
@@ -83,11 +84,11 @@ final class PercentageCalculatorTests: XCTestCase {
             cappedAt100: false
         )
 
-        XCTAssertEqual(percentage, 125.0, accuracy: 0.01,
-                      "Should return over 100% when exceeding token limit and uncapped")
+        #expect(abs(percentage - 125.0) < 0.01,
+               "Should return over 100% when exceeding token limit and uncapped")
     }
 
-    func testCalculateTokenPercentage_consistentWithManualCalculation() {
+    @Test func calculateTokenPercentage_consistentWithManualCalculation() {
         // Test that our method matches the original manual calculation
         let currentTokens = 150000
         let tokenLimit = 200000
@@ -100,7 +101,7 @@ final class PercentageCalculatorTests: XCTestCase {
 
         let manualResult = (Double(currentTokens) / Double(tokenLimit)) * 100.0
 
-        XCTAssertEqual(calculatorResult, manualResult, accuracy: 0.01,
-                      "PercentageCalculator result should match original manual calculation")
+        #expect(abs(calculatorResult - manualResult) < 0.01,
+               "PercentageCalculator result should match original manual calculation")
     }
 }

--- a/q-status-menubar/Tests/CoreTests/SessionBlockCalculatorTests.swift
+++ b/q-status-menubar/Tests/CoreTests/SessionBlockCalculatorTests.swift
@@ -1,10 +1,12 @@
 // ABOUTME: Tests for SessionBlockCalculator - validates session block grouping algorithm
 // This file contains comprehensive tests for the 5-hour session block calculator
 
-import XCTest
+import Testing
+import Foundation
 @testable import Core
 
-final class SessionBlockCalculatorTests: XCTestCase {
+@Suite("SessionBlockCalculator")
+struct SessionBlockCalculatorTests {
 
     // MARK: - Test Helpers
 
@@ -56,12 +58,12 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
     // MARK: - Basic Functionality Tests
 
-    func testEmptyEntries() {
+    @Test func emptyEntries() {
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: [])
-        XCTAssertEqual(blocks.count, 0, "Should return empty array for empty entries")
+        #expect(blocks.count == 0, "Should return empty array for empty entries")
     }
 
-    func testSingleBlockWithinFiveHours() {
+    @Test func singleBlockWithinFiveHours() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime),
@@ -71,15 +73,15 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 1, "Should create single block for entries within 5 hours")
-        XCTAssertEqual(blocks[0].startTime, baseTime, "Block should start at first entry time (floored)")
-        XCTAssertEqual(blocks[0].entries.count, 3, "Block should contain all 3 entries")
-        XCTAssertEqual(blocks[0].tokenCounts.inputTokens, 3000, "Should aggregate input tokens")
-        XCTAssertEqual(blocks[0].tokenCounts.outputTokens, 1500, "Should aggregate output tokens")
-        XCTAssertEqual(blocks[0].costUSD, 0.03, accuracy: 0.001, "Should aggregate costs")
+        #expect(blocks.count == 1, "Should create single block for entries within 5 hours")
+        #expect(blocks[0].startTime == baseTime, "Block should start at first entry time (floored)")
+        #expect(blocks[0].entries.count == 3, "Block should contain all 3 entries")
+        #expect(blocks[0].tokenCounts.inputTokens == 3000, "Should aggregate input tokens")
+        #expect(blocks[0].tokenCounts.outputTokens == 1500, "Should aggregate output tokens")
+        #expect(abs(blocks[0].costUSD - 0.03) < 0.001, "Should aggregate costs")
     }
 
-    func testMultipleBlocksSpanningMoreThanFiveHours() {
+    @Test func multipleBlocksSpanningMoreThanFiveHours() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime),
@@ -88,15 +90,15 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 3, "Should create first block, gap block, and second block")
-        XCTAssertEqual(blocks[0].entries.count, 1, "First block should have 1 entry")
-        XCTAssertTrue(blocks[1].isGap, "Second block should be a gap block")
-        XCTAssertEqual(blocks[2].entries.count, 1, "Third block should have 1 entry")
+        #expect(blocks.count == 3, "Should create first block, gap block, and second block")
+        #expect(blocks[0].entries.count == 1, "First block should have 1 entry")
+        #expect(blocks[1].isGap, "Second block should be a gap block")
+        #expect(blocks[2].entries.count == 1, "Third block should have 1 entry")
     }
 
     // MARK: - Gap Detection Tests
 
-    func testGapBlockCreation() {
+    @Test func gapBlockCreation() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime),
@@ -106,14 +108,14 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 3, "Should create first block, gap block, and second block")
-        XCTAssertEqual(blocks[0].entries.count, 2, "First block should have 2 entries")
-        XCTAssertTrue(blocks[1].isGap, "Second block should be a gap block")
-        XCTAssertEqual(blocks[1].entries.count, 0, "Gap block should have no entries")
-        XCTAssertEqual(blocks[2].entries.count, 1, "Third block should have 1 entry")
+        #expect(blocks.count == 3, "Should create first block, gap block, and second block")
+        #expect(blocks[0].entries.count == 2, "First block should have 2 entries")
+        #expect(blocks[1].isGap, "Second block should be a gap block")
+        #expect(blocks[1].entries.count == 0, "Gap block should have no entries")
+        #expect(blocks[2].entries.count == 1, "Third block should have 1 entry")
     }
 
-    func testNoGapBlockForShortGaps() {
+    @Test func noGapBlockForShortGaps() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime),
@@ -122,28 +124,28 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 1, "Should create single block without gap")
-        XCTAssertEqual(blocks[0].entries.count, 2, "Block should contain both entries")
+        #expect(blocks.count == 1, "Should create single block without gap")
+        #expect(blocks[0].entries.count == 2, "Block should contain both entries")
     }
 
     // MARK: - Time Handling Tests
 
-    func testFloorToHour() {
+    @Test func floorToHour() {
         let entryTime = createDate(year: 2024, month: 1, day: 1, hour: 10, minute: 55, second: 30)
         let expectedStartTime = createDate(year: 2024, month: 1, day: 1, hour: 10, minute: 0, second: 0)
         let entries = [createMockEntry(timestamp: entryTime)]
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 1, "Should create one block")
-        XCTAssertEqual(blocks[0].startTime, expectedStartTime, "Block start time should be floored to hour")
+        #expect(blocks.count == 1, "Should create one block")
+        #expect(blocks[0].startTime == expectedStartTime, "Block start time should be floored to hour")
 
         let formatter = ISO8601DateFormatter()
         formatter.timeZone = TimeZone(identifier: "UTC")
-        XCTAssertEqual(blocks[0].id, formatter.string(from: expectedStartTime), "Block ID should use floored time")
+        #expect(blocks[0].id == formatter.string(from: expectedStartTime), "Block ID should use floored time")
     }
 
-    func testSortingUnsortedEntries() {
+    @Test func sortingUnsortedEntries() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime.addingTimeInterval(2 * 3600)), // 2 hours later
@@ -153,21 +155,21 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 1, "Should create single block")
-        XCTAssertEqual(blocks[0].entries.count, 3, "Block should contain all entries")
+        #expect(blocks.count == 1, "Should create single block")
+        #expect(blocks[0].entries.count == 3, "Block should contain all entries")
 
         // Verify entries are sorted
         if let firstDate = blocks[0].entries[0].date,
            let secondDate = blocks[0].entries[1].date,
            let thirdDate = blocks[0].entries[2].date {
-            XCTAssertLessThan(firstDate, secondDate, "Entries should be sorted")
-            XCTAssertLessThan(secondDate, thirdDate, "Entries should be sorted")
+            #expect(firstDate < secondDate, "Entries should be sorted")
+            #expect(secondDate < thirdDate, "Entries should be sorted")
         }
     }
 
     // MARK: - Custom Duration Tests
 
-    func testCustomSessionDuration() {
+    @Test func customSessionDuration() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime),
@@ -177,13 +179,13 @@ final class SessionBlockCalculatorTests: XCTestCase {
         // Test with 2-hour duration
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries, sessionDurationHours: 2)
 
-        XCTAssertEqual(blocks.count, 3, "Should create first block, gap block, and second block with 2-hour duration")
-        XCTAssertEqual(blocks[0].entries.count, 1, "First block should have 1 entry")
-        XCTAssertTrue(blocks[1].isGap, "Second block should be a gap block")
-        XCTAssertEqual(blocks[2].entries.count, 1, "Third block should have 1 entry")
+        #expect(blocks.count == 3, "Should create first block, gap block, and second block with 2-hour duration")
+        #expect(blocks[0].entries.count == 1, "First block should have 1 entry")
+        #expect(blocks[1].isGap, "Second block should be a gap block")
+        #expect(blocks[2].entries.count == 1, "Third block should have 1 entry")
     }
 
-    func testVeryShortDuration() {
+    @Test func veryShortDuration() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime),
@@ -194,15 +196,15 @@ final class SessionBlockCalculatorTests: XCTestCase {
         // Test with 0.5 hour (30 minutes) duration
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries, sessionDurationHours: 0.5)
 
-        XCTAssertEqual(blocks.count, 3, "Should create multiple blocks with short duration")
-        XCTAssertEqual(blocks[0].entries.count, 2, "First block should have 2 entries within 30 minutes")
-        XCTAssertTrue(blocks[1].isGap, "Should have gap block")
-        XCTAssertEqual(blocks[2].entries.count, 1, "Last block should have 1 entry")
+        #expect(blocks.count == 3, "Should create multiple blocks with short duration")
+        #expect(blocks[0].entries.count == 2, "First block should have 2 entries within 30 minutes")
+        #expect(blocks[1].isGap, "Should have gap block")
+        #expect(blocks[2].entries.count == 1, "Last block should have 1 entry")
     }
 
     // MARK: - Token and Cost Aggregation Tests
 
-    func testTokenAggregation() {
+    @Test func tokenAggregation() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime, inputTokens: 1000, outputTokens: 500),
@@ -212,13 +214,13 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 1, "Should create single block")
-        XCTAssertEqual(blocks[0].tokenCounts.inputTokens, 4500, "Should sum input tokens")
-        XCTAssertEqual(blocks[0].tokenCounts.outputTokens, 2250, "Should sum output tokens")
-        XCTAssertEqual(blocks[0].tokenCounts.totalTokens, 6750, "Should calculate total tokens correctly")
+        #expect(blocks.count == 1, "Should create single block")
+        #expect(blocks[0].tokenCounts.inputTokens == 4500, "Should sum input tokens")
+        #expect(blocks[0].tokenCounts.outputTokens == 2250, "Should sum output tokens")
+        #expect(blocks[0].tokenCounts.totalTokens == 6750, "Should calculate total tokens correctly")
     }
 
-    func testCacheTokenHandling() {
+    @Test func cacheTokenHandling() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
 
         let formatter = ISO8601DateFormatter()
@@ -246,12 +248,12 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: [entry])
 
-        XCTAssertEqual(blocks[0].tokenCounts.cacheCreationInputTokens, 100, "Should track cache creation tokens")
-        XCTAssertEqual(blocks[0].tokenCounts.cacheReadInputTokens, 200, "Should track cache read tokens")
-        XCTAssertEqual(blocks[0].tokenCounts.totalTokens, 1800, "Should include cache tokens in total")
+        #expect(blocks[0].tokenCounts.cacheCreationInputTokens == 100, "Should track cache creation tokens")
+        #expect(blocks[0].tokenCounts.cacheReadInputTokens == 200, "Should track cache read tokens")
+        #expect(blocks[0].tokenCounts.totalTokens == 1800, "Should include cache tokens in total")
     }
 
-    func testModelAggregation() {
+    @Test func modelAggregation() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime, model: "claude-3-5-sonnet"),
@@ -261,15 +263,15 @@ final class SessionBlockCalculatorTests: XCTestCase {
 
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
 
-        XCTAssertEqual(blocks.count, 1, "Should create single block")
-        XCTAssertEqual(blocks[0].models.count, 2, "Should have 2 unique models")
-        XCTAssertTrue(blocks[0].models.contains("claude-3-5-sonnet"), "Should contain sonnet model")
-        XCTAssertTrue(blocks[0].models.contains("claude-3-opus"), "Should contain opus model")
+        #expect(blocks.count == 1, "Should create single block")
+        #expect(blocks[0].models.count == 2, "Should have 2 unique models")
+        #expect(blocks[0].models.contains("claude-3-5-sonnet"), "Should contain sonnet model")
+        #expect(blocks[0].models.contains("claude-3-opus"), "Should contain opus model")
     }
 
     // MARK: - Burn Rate Tests
 
-    func testBurnRateCalculation() {
+    @Test func burnRateCalculation() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
         let entries = [
             createMockEntry(timestamp: baseTime, inputTokens: 1000, outputTokens: 500, costUSD: 0.01),
@@ -279,15 +281,15 @@ final class SessionBlockCalculatorTests: XCTestCase {
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
         let burnRate = BurnRateCalculator.calculateBurnRate(for: blocks[0])
 
-        XCTAssertNotNil(burnRate, "Should calculate burn rate")
+        #expect(burnRate != nil, "Should calculate burn rate")
         if let burnRate = burnRate {
-            XCTAssertEqual(burnRate.tokensPerMinute, 4500, accuracy: 0.1, "Should calculate 4500 tokens/minute")
-            XCTAssertEqual(burnRate.tokensPerMinuteForIndicator, 4500, accuracy: 0.1, "Should calculate indicator rate")
-            XCTAssertEqual(burnRate.costPerHour, 1.8, accuracy: 0.01, "Should calculate $1.80/hour")
+            #expect(abs(burnRate.tokensPerMinute - 4500) < 0.1, "Should calculate 4500 tokens/minute")
+            #expect(abs(burnRate.tokensPerMinuteForIndicator - 4500) < 0.1, "Should calculate indicator rate")
+            #expect(abs(burnRate.costPerHour - 1.8) < 0.01, "Should calculate $1.80/hour")
         }
     }
 
-    func testBurnRateWithCacheTokens() {
+    @Test func burnRateWithCacheTokens() {
         let baseTime = createDate(year: 2024, month: 1, day: 1, hour: 10)
 
         let formatter = ISO8601DateFormatter()
@@ -337,14 +339,14 @@ final class SessionBlockCalculatorTests: XCTestCase {
         let blocks = SessionBlockCalculator.identifySessionBlocks(entries: entries)
         let burnRate = BurnRateCalculator.calculateBurnRate(for: blocks[0])
 
-        XCTAssertNotNil(burnRate, "Should calculate burn rate")
+        #expect(burnRate != nil, "Should calculate burn rate")
         if let burnRate = burnRate {
-            XCTAssertEqual(burnRate.tokensPerMinute, 12200, accuracy: 0.1, "Should include all tokens")
-            XCTAssertEqual(burnRate.tokensPerMinuteForIndicator, 2200, accuracy: 0.1, "Should exclude cache tokens for indicator")
+            #expect(abs(burnRate.tokensPerMinute - 12200) < 0.1, "Should include all tokens")
+            #expect(abs(burnRate.tokensPerMinuteForIndicator - 2200) < 0.1, "Should exclude cache tokens for indicator")
         }
     }
 
-    func testBurnRateReturnsNilForEmptyBlock() {
+    @Test func burnRateReturnsNilForEmptyBlock() {
         let block = SessionBlock(
             id: "test",
             startTime: Date(),
@@ -354,10 +356,10 @@ final class SessionBlockCalculatorTests: XCTestCase {
         )
 
         let burnRate = BurnRateCalculator.calculateBurnRate(for: block)
-        XCTAssertNil(burnRate, "Should return nil for empty block")
+        #expect(burnRate == nil, "Should return nil for empty block")
     }
 
-    func testBurnRateReturnsNilForGapBlock() {
+    @Test func burnRateReturnsNilForGapBlock() {
         let block = SessionBlock(
             id: "gap-test",
             startTime: Date(),
@@ -366,12 +368,12 @@ final class SessionBlockCalculatorTests: XCTestCase {
         )
 
         let burnRate = BurnRateCalculator.calculateBurnRate(for: block)
-        XCTAssertNil(burnRate, "Should return nil for gap block")
+        #expect(burnRate == nil, "Should return nil for gap block")
     }
 
     // MARK: - Projection Tests
 
-    func testProjectedUsageReturnsNilForInactiveBlock() {
+    @Test func projectedUsageReturnsNilForInactiveBlock() {
         let block = SessionBlock(
             id: "test",
             startTime: Date(),
@@ -381,10 +383,10 @@ final class SessionBlockCalculatorTests: XCTestCase {
         )
 
         let projection = ProjectedUsageCalculator.projectBlockUsage(for: block)
-        XCTAssertNil(projection, "Should return nil for inactive block")
+        #expect(projection == nil, "Should return nil for inactive block")
     }
 
-    func testProjectedUsageReturnsNilForGapBlock() {
+    @Test func projectedUsageReturnsNilForGapBlock() {
         let block = SessionBlock(
             id: "gap-test",
             startTime: Date(),
@@ -394,12 +396,12 @@ final class SessionBlockCalculatorTests: XCTestCase {
         )
 
         let projection = ProjectedUsageCalculator.projectBlockUsage(for: block)
-        XCTAssertNil(projection, "Should return nil for gap block")
+        #expect(projection == nil, "Should return nil for gap block")
     }
 
     // MARK: - Filter Tests
 
-    func testFilterRecentBlocks() {
+    @Test func filterRecentBlocks() {
         let now = Date()
         let recentTime = now.addingTimeInterval(-2 * 24 * 3600) // 2 days ago
         let oldTime = now.addingTimeInterval(-5 * 24 * 3600)    // 5 days ago
@@ -421,11 +423,11 @@ final class SessionBlockCalculatorTests: XCTestCase {
         let blocks = [recentBlock, oldBlock]
         let filtered = SessionBlockFilter.filterRecentBlocks(blocks)
 
-        XCTAssertEqual(filtered.count, 1, "Should filter out old blocks")
-        XCTAssertEqual(filtered[0].id, "recent", "Should keep recent block")
+        #expect(filtered.count == 1, "Should filter out old blocks")
+        #expect(filtered[0].id == "recent", "Should keep recent block")
     }
 
-    func testFilterIncludesActiveBlocks() {
+    @Test func filterIncludesActiveBlocks() {
         let now = Date()
         let oldTime = now.addingTimeInterval(-10 * 24 * 3600) // 10 days ago
 
@@ -439,11 +441,11 @@ final class SessionBlockCalculatorTests: XCTestCase {
         let blocks = [oldActiveBlock]
         let filtered = SessionBlockFilter.filterRecentBlocks(blocks, days: 3)
 
-        XCTAssertEqual(filtered.count, 1, "Should include active blocks regardless of age")
-        XCTAssertTrue(filtered[0].isActive, "Block should be active")
+        #expect(filtered.count == 1, "Should include active blocks regardless of age")
+        #expect(filtered[0].isActive, "Block should be active")
     }
 
-    func testFilterWithCustomDays() {
+    @Test func filterWithCustomDays() {
         let now = Date()
         let withinRange = now.addingTimeInterval(-4 * 24 * 3600)  // 4 days ago
         let outsideRange = now.addingTimeInterval(-8 * 24 * 3600) // 8 days ago
@@ -465,7 +467,7 @@ final class SessionBlockCalculatorTests: XCTestCase {
         let blocks = [withinBlock, outsideBlock]
         let filtered = SessionBlockFilter.filterRecentBlocks(blocks, days: 7)
 
-        XCTAssertEqual(filtered.count, 1, "Should respect custom day parameter")
-        XCTAssertEqual(filtered[0].id, "within", "Should keep block within range")
+        #expect(filtered.count == 1, "Should respect custom day parameter")
+        #expect(filtered[0].id == "within", "Should keep block within range")
     }
 }

--- a/q-status-menubar/Tests/CoreTests/SettingsIntegrationTest.swift
+++ b/q-status-menubar/Tests/CoreTests/SettingsIntegrationTest.swift
@@ -1,12 +1,13 @@
 // ABOUTME: Integration test to verify Settings.swift uses centralized PercentageCalculator
 // Ensures the Claude token percentage calculation is correctly delegated to PercentageCalculator
 
-import XCTest
+import Testing
 @testable import Core
 
-final class SettingsIntegrationTest: XCTestCase {
+@Suite("SettingsIntegration")
+struct SettingsIntegrationTests {
 
-    func testClaudeTokenLimitPercentage_usesPercentageCalculator() {
+    @Test func claudeTokenLimitPercentage_usesPercentageCalculator() {
         // Verify that Settings.claudeTokenLimitPercentage uses PercentageCalculator
         let settings = SettingsStore()
         settings.claudeTokenLimit = 200000
@@ -24,20 +25,20 @@ final class SettingsIntegrationTest: XCTestCase {
         )
 
         // They should be identical
-        XCTAssertEqual(settingsResult, calculatorResult, accuracy: 0.01,
-                      "Settings.claudeTokenLimitPercentage should use PercentageCalculator internally")
+        #expect(abs(settingsResult - calculatorResult) < 0.01,
+               "Settings.claudeTokenLimitPercentage should use PercentageCalculator internally")
 
         // Verify the actual percentage value
-        XCTAssertEqual(settingsResult, 75.0, accuracy: 0.01,
-                      "150K tokens out of 200K limit should be 75%")
+        #expect(abs(settingsResult - 75.0) < 0.01,
+               "150K tokens out of 200K limit should be 75%")
     }
 
-    func testClaudeTokenLimitPercentage_behaviorMatchesOriginal() {
+    @Test func claudeTokenLimitPercentage_behaviorMatchesOriginal() {
         // Ensure the behavior matches the original manual calculation
         let settings = SettingsStore()
         settings.claudeTokenLimit = 200000
 
-        let testCases = [
+        let testCases: [(tokens: Int, expected: Double)] = [
             (tokens: 0, expected: 0.0),
             (tokens: 50000, expected: 25.0),
             (tokens: 100000, expected: 50.0),
@@ -50,10 +51,10 @@ final class SettingsIntegrationTest: XCTestCase {
             let result = settings.claudeTokenLimitPercentage(currentTokens: tokens)
             let originalCalculation = (Double(tokens) / Double(settings.claudeTokenLimit)) * 100.0
 
-            XCTAssertEqual(result, expected, accuracy: 0.01,
-                          "Failed for \(tokens) tokens: expected \(expected)%, got \(result)%")
-            XCTAssertEqual(result, originalCalculation, accuracy: 0.01,
-                          "Should match original manual calculation for \(tokens) tokens")
+            #expect(abs(result - expected) < 0.01,
+                   "Failed for \(tokens) tokens: expected \(expected)%, got \(result)%")
+            #expect(abs(result - originalCalculation) < 0.01,
+                   "Should match original manual calculation for \(tokens) tokens")
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of qstatus menubar v2 — fixes all 6 data correctness bugs identified by Splinter. No new providers, no UI changes.

### Bugs Fixed

| # | Severity | Problem | Fix |
|---|----------|---------|-----|
| BUG-1 | CRITICAL | Period metrics (day/week/month) returned all-time totals | Added timestamp filters to `fetchPeriodTokensByModel(now:)` |
| BUG-2 | HIGH | Context window hardcoded to 175k in UpdateCoordinator, overriding per-session value | Removed override in `applySessions`, preserves DB value |
| BUG-3 | HIGH | Latest session selected by rowid (insertion order), not actual activity | SQL CTE with `MAX(timestamp)` from json_each history, rowid fallback |
| BUG-4 | HIGH | Monthly message count unfiltered — returned all-time count | json_each query with `WHERE timestamp >= startOfMonth` |
| BUG-5 | MEDIUM | Three divergent token estimators producing inconsistent numbers | All paths unified through `TokenEstimator.estimate(charCount:)` |
| BUG-6 | MEDIUM | `sessionCount(activeOnly:)` ignored the parameter | 7-day activity filter applied when `activeOnly == true` |

### Tests

9 new tests in `Tests/CoreTests/BugFixTests.swift` — all seeded with in-memory temp SQLite (no dependency on live Amazon Q DB):
- `testDailyMetricsExcludeYesterdayData`
- `testWeeklyMetricsExcludeLastWeekData`
- `testMonthlyMessageCountFiltersToCurrentMonth`
- `testLatestSessionByActivityNotRowid`
- `testActiveOnlyCountMatchesActiveOnlyFetch`
- `testEstimateGoldenCase4000chars`
- `testEstimateGoldenCase4001chars`
- `testEstimatorIsConsistentAcrossAllCodePaths`
- `testPreservesPerSessionContextWindow`

### What's not in this PR
- New providers (Copilot Enterprise, Codex CLI) — Phase 2/3
- TUI changes — deferred to v3
- Amazon Q estimates not removed — kept but correctness improved

Also migrates test suite from XCTest to Swift Testing framework (required for non-Xcode CommandLineTools environments).

Spec: `~/d/splinter-agent/research-work/qstatus/plans/qstatus-menubar-v2-spec.md`
Inbox: `kh79eb30c191jrt9jf73ndhwgs83p8h5`